### PR TITLE
Add support for new realm API in cookieauth (fixes violation of rfc2617#page-3)

### DIFF
--- a/serve/config.go
+++ b/serve/config.go
@@ -14,4 +14,5 @@ type Config struct {
 	Quiet      bool   `help:"Disable all output"`
 	TimeFmt    string `help:"Set timestamp output format"`
 	Fallback   string `help:"Requests that yeild a 404, will instead proxy through to the provided path (swaps in the appropriate Host header)"`
+	Realm      string `help:"Set the realm for the authentication response"`
 }

--- a/serve/handler.go
+++ b/serve/handler.go
@@ -109,7 +109,7 @@ func NewHandler(c Config) (http.Handler, error) {
 		if len(auth) < 2 {
 			return nil, fmt.Errorf("should be in the form 'user:pass'")
 		}
-		h = cookieauth.Wrap(h, auth[0], auth[1])
+		h = cookieauth.Wrap(h, auth[0], auth[1], c.Realm)
 	}
 	//logging is enabled
 	if !c.Quiet {

--- a/serve/handler.go
+++ b/serve/handler.go
@@ -109,7 +109,7 @@ func NewHandler(c Config) (http.Handler, error) {
 		if len(auth) < 2 {
 			return nil, fmt.Errorf("should be in the form 'user:pass'")
 		}
-		h = cookieauth.Wrap(h, auth[0], auth[1], c.Realm)
+		h = cookieauth.WrapWithRealm(h, auth[0], auth[1], c.Realm)
 	}
 	//logging is enabled
 	if !c.Quiet {


### PR DESCRIPTION
This PR adds support for the realm configuration set in the header of an authentication response made by https://github.com/jpillora/cookieauth